### PR TITLE
Add TargetedActionScope to allow linkage to actions in a child widget.

### DIFF
--- a/lib/global/targeted_actions.dart
+++ b/lib/global/targeted_actions.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+class TargetedActionRoot extends StatefulWidget {
+  TargetedActionRoot({Key? key, required this.child}) : super(key: key);
+
+  final Widget child;
+
+  @override
+  State<TargetedActionRoot> createState() => _TargetedActionRootState();
+}
+
+class _TargetedActionRootState extends State<TargetedActionRoot> {
+  late _TargetedActionRegistry registry;
+  late final GlobalKey registryKey;
+  Map<ShortcutActivator, Intent> mappedShortcuts = <ShortcutActivator, Intent>{};
+
+  @override
+  void initState() {
+    super.initState();
+    registryKey = GlobalKey();
+    registry = _TargetedActionRegistry(registryKey: registryKey);
+    registry.addListener(_registryChanged);
+    mappedShortcuts = _buildShortcuts();
+  }
+
+  @override
+  void dispose() {
+    registry.removeListener(_registryChanged);
+    super.dispose();
+  }
+
+  void _registryChanged() {
+    setState(() {
+      mappedShortcuts = _buildShortcuts();
+    });
+  }
+
+  Map<ShortcutActivator, Intent> _buildShortcuts() {
+    Map<ShortcutActivator, Intent> mapped = <ShortcutActivator, Intent>{};
+    for (final ShortcutActivator activator in registry.shortcuts.keys) {
+      mapped[activator] = _TargetedIntent(registry.registryKey, registry.shortcuts[activator]!);
+    }
+    return mapped;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    registry.inBuild = true;
+    Widget result = ChangeNotifierProvider<_TargetedActionRegistry>.value(
+      value: registry,
+      child: Shortcuts(
+        shortcuts: mappedShortcuts,
+        child: Actions(
+          actions: <Type, Action<Intent>>{
+            _TargetedIntent: _TargetedAction(),
+          },
+          child: KeyedSubtree(
+            key: registryKey,
+            child: widget.child,
+          ),
+        ),
+      ),
+    );
+    registry.inBuild = false;
+    return result;
+  }
+}
+
+class TargetedActionBinding extends StatelessWidget {
+  TargetedActionBinding({Key? key, required this.child, required this.shortcuts, this.actions})
+      : _subtreeKey = GlobalKey(),
+        super(key: key);
+
+  final Widget child;
+  final Map<ShortcutActivator, Intent> shortcuts;
+  final Map<Type, Action<Intent>>? actions;
+  final GlobalKey _subtreeKey;
+
+  @override
+  Widget build(BuildContext context) {
+    _TargetedActionRegistry registry = Provider.of<_TargetedActionRegistry>(context);
+    registry.addShortcuts(shortcuts);
+    registry.targetKey = _subtreeKey;
+    Widget child = KeyedSubtree(
+      key: _subtreeKey,
+      child: this.child,
+    );
+    if (actions != null) {
+      child = Actions(actions: actions!, child: child);
+    }
+    return Shortcuts(
+      shortcuts: shortcuts,
+      child: child,
+    );
+  }
+}
+
+class _TargetedActionRegistry extends ChangeNotifier {
+  _TargetedActionRegistry({GlobalKey? initialKey, required this.registryKey})
+      : _targetKey = initialKey,
+        _shortcuts = <ShortcutActivator, Intent>{};
+
+  GlobalKey? get targetKey => _targetKey;
+  GlobalKey? _targetKey;
+  set targetKey(GlobalKey? value) {
+    if (_targetKey != value) {
+      _targetKey = value;
+      scheduleMicrotask(() => notifyListeners());
+    }
+  }
+
+  bool get inBuild => _inBuild;
+  bool _inBuild = false;
+  set inBuild(bool value) {
+    if (_inBuild != value) {
+      _inBuild = value;
+      if (inBuild) {
+        _shortcuts.clear();
+      } else {
+        // Have to do this in a microtask because children can't cause parents
+        // to rebuild during the build. This means causing an extra frame
+        // whenever the root builds.
+        scheduleMicrotask(() => notifyListeners());
+      }
+    }
+  }
+
+  Map<ShortcutActivator, Intent> get shortcuts => _shortcuts;
+  Map<ShortcutActivator, Intent> _shortcuts;
+  void addShortcuts(Map<ShortcutActivator, Intent> value) {
+    assert(value.keys.toSet().intersection(_shortcuts.keys.toSet()).isEmpty,
+      'Warning: duplicate key binding for these activators: ${value.keys.toSet().intersection(_shortcuts.keys.toSet())}'
+    );
+    _shortcuts.addAll(value);
+  }
+
+  final GlobalKey registryKey;
+
+  Object? invoke(Intent intent) {
+    if (targetKey != null && targetKey!.currentContext != null) {
+      return Actions.invoke(targetKey!.currentContext!, intent);
+    }
+    return null;
+  }
+}
+
+class _TargetedIntent extends Intent {
+  const _TargetedIntent(this.registryKey, this.intent);
+
+  final GlobalKey registryKey;
+  final Intent intent;
+}
+
+class _TargetedAction extends Action<_TargetedIntent> {
+  _TargetedAction();
+
+  @override
+  Object? invoke(covariant _TargetedIntent intent) {
+    if (intent.registryKey.currentContext != null) {
+      Provider.of<_TargetedActionRegistry>(intent.registryKey.currentContext!, listen: false)
+          .invoke(intent.intent);
+    }
+  }
+}

--- a/lib/main_app_scaffold.dart
+++ b/lib/main_app_scaffold.dart
@@ -10,6 +10,7 @@ import 'package:adaptive_app_demos/widgets/buttons.dart';
 import 'package:adaptive_app_demos/widgets/ok_cancel_dialog.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import 'widgets/app_title_bar.dart';
@@ -40,7 +41,12 @@ class _MainAppScaffoldState extends State<MainAppScaffold> {
   Widget build(BuildContext context) {
     bool useTabs = MediaQuery.of(context).size.width < FormFactor.tablet;
     bool isLoggedOut = context.select((AppModel m) => m.isLoggedIn) == false;
-    return TargetedActionRoot(
+    return TargetedActionScope(
+      shortcuts: <LogicalKeySet, Intent>{
+        LogicalKeySet(LogicalKeyboardKey.keyA, LogicalKeyboardKey.control): SelectAllIntent(),
+        LogicalKeySet(LogicalKeyboardKey.keyS, LogicalKeyboardKey.control): SelectNoneIntent(),
+        LogicalKeySet(LogicalKeyboardKey.delete): DeleteIntent(),
+      },
       child: WindowBorder(
         color: Colors.white,
         child: Material(

--- a/lib/main_app_scaffold.dart
+++ b/lib/main_app_scaffold.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'widgets/app_title_bar.dart';
+import 'global/targeted_actions.dart';
 
 List<Widget> getMainMenuChildren(BuildContext context) {
   // Define a method to change pages in the AppModel
@@ -39,44 +40,49 @@ class _MainAppScaffoldState extends State<MainAppScaffold> {
   Widget build(BuildContext context) {
     bool useTabs = MediaQuery.of(context).size.width < FormFactor.tablet;
     bool isLoggedOut = context.select((AppModel m) => m.isLoggedIn) == false;
-    return WindowBorder(
-      color: Colors.white,
-      child: Material(
-        child: Column(
-          children: [
-            AppTitleBar(),
-            Expanded(
-              child: isLoggedOut
-                  // If logged out, show just the login page with no menus
-                  ? LoginPage()
-                  // Otherwise, show the full application with dynamic scaffold
-                  : Scaffold(
-                      key: _scaffoldKey,
-                      drawer: useTabs ? _SideMenu(showPageButtons: false) : null,
-                      appBar: useTabs ? AppBar(backgroundColor: Colors.blue.shade300) : null,
-                      body: Stack(children: [
-                        // Vertical layout with Tab controller and drawer
-                        if (useTabs) ...[
-                          Column(
-                            children: [
-                              Expanded(child: _PageStack()),
-                              _TabMenu(),
+    return TargetedActionRoot(
+      child: WindowBorder(
+        color: Colors.white,
+        child: Material(
+          child: Column(
+            children: [
+              AppTitleBar(),
+              Expanded(
+                child: isLoggedOut
+                    // If logged out, show just the login page with no menus
+                    ? LoginPage()
+                    // Otherwise, show the full application with dynamic scaffold
+                    : Focus(
+                      autofocus: true,
+                      child: Scaffold(
+                          key: _scaffoldKey,
+                          drawer: useTabs ? _SideMenu(showPageButtons: false) : null,
+                          appBar: useTabs ? AppBar(backgroundColor: Colors.blue.shade300) : null,
+                          body: Stack(children: [
+                            // Vertical layout with Tab controller and drawer
+                            if (useTabs) ...[
+                              Column(
+                                children: [
+                                  Expanded(child: _PageStack()),
+                                  _TabMenu(),
+                                ],
+                              )
+                            ]
+                            // Horizontal layout with desktop style side menu
+                            else ...[
+                              Row(
+                                children: [
+                                  _SideMenu(),
+                                  Expanded(child: _PageStack()),
+                                ],
+                              ),
                             ],
-                          )
-                        ]
-                        // Horizontal layout with desktop style side menu
-                        else ...[
-                          Row(
-                            children: [
-                              _SideMenu(),
-                              Expanded(child: _PageStack()),
-                            ],
-                          ),
-                        ],
-                      ]),
+                          ]),
+                        ),
                     ),
-            ),
-          ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -119,9 +125,7 @@ class _SideMenu extends StatelessWidget {
           // Buttons
           Column(children: [
             SizedBox(height: Insets.extraLarge),
-            if (showPageButtons) ...[
-              ...getMainMenuChildren(context),
-            ],
+            if (showPageButtons)...getMainMenuChildren(context),
             SizedBox(height: Insets.extraLarge),
             SecondaryMenuButton(label: "Submenu Item 1"),
             SecondaryMenuButton(label: "Submenu Item 2"),

--- a/lib/pages/adaptive_grid_page.dart
+++ b/lib/pages/adaptive_grid_page.dart
@@ -5,7 +5,6 @@ import 'package:adaptive_app_demos/global/styling.dart';
 import 'package:adaptive_app_demos/global/targeted_actions.dart';
 import 'package:adaptive_app_demos/widgets/buttons.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 class AdaptiveGridPage extends StatefulWidget {
   @override
@@ -24,13 +23,7 @@ class _AdaptiveGridPageState extends State<AdaptiveGridPage> {
     Widget buildGridItem(int index) =>
         _GridItem(index, isSelected: _selectedItems.contains(index), onPressed: _handleItemPressed);
     List<Widget> listChildren = _listItems.map(buildGridItem).toList();
-    print("build");
     return TargetedActionBinding(
-      shortcuts: <ShortcutActivator, Intent>{
-        LogicalKeySet(LogicalKeyboardKey.keyA, LogicalKeyboardKey.control): SelectAllIntent(),
-        LogicalKeySet(LogicalKeyboardKey.keyL, LogicalKeyboardKey.control): SelectNoneIntent(),
-        LogicalKeySet(LogicalKeyboardKey.delete): DeleteIntent(),
-      },
       actions: {
         SelectAllIntent: CallbackAction(onInvoke: (Intent intent) => this._handleSelectAllPressed()),
         SelectNoneIntent: CallbackAction(onInvoke: (Intent intent) => this._handleSelectNonePressed()),

--- a/lib/pages/adaptive_grid_page.dart
+++ b/lib/pages/adaptive_grid_page.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:adaptive_app_demos/global/device_type.dart';
 import 'package:adaptive_app_demos/global/styling.dart';
+import 'package:adaptive_app_demos/global/targeted_actions.dart';
 import 'package:adaptive_app_demos/widgets/buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -23,46 +24,45 @@ class _AdaptiveGridPageState extends State<AdaptiveGridPage> {
     Widget buildGridItem(int index) =>
         _GridItem(index, isSelected: _selectedItems.contains(index), onPressed: _handleItemPressed);
     List<Widget> listChildren = _listItems.map(buildGridItem).toList();
-    return Shortcuts(
+    print("build");
+    return TargetedActionBinding(
       shortcuts: <ShortcutActivator, Intent>{
         LogicalKeySet(LogicalKeyboardKey.keyA, LogicalKeyboardKey.control): SelectAllIntent(),
+        LogicalKeySet(LogicalKeyboardKey.keyL, LogicalKeyboardKey.control): SelectNoneIntent(),
         LogicalKeySet(LogicalKeyboardKey.delete): DeleteIntent(),
       },
-      child: Actions(
-        actions: {
-          SelectAllIntent: SelectAllAction(this._handleSelectAllPressed),
-          DeleteIntent: DeleteAction(this._handleDeleteSelectedPressed),
-        },
-        child: Focus(
-          child: Column(
+      actions: {
+        SelectAllIntent: CallbackAction(onInvoke: (Intent intent) => this._handleSelectAllPressed()),
+        SelectNoneIntent: CallbackAction(onInvoke: (Intent intent) => this._handleSelectNonePressed()),
+        DeleteIntent: CallbackAction(onInvoke: (Intent intent) => this._handleDeleteSelectedPressed()),
+      },
+      child: Column(
+        children: [
+          Row(
             children: [
-              Row(
-                children: [
-                  StyledTextButton(onPressed: _handleSelectAllPressed, child: Text("Select All")),
-                  StyledTextButton(onPressed: _handleSelectNonePressed, child: Text("Select None")),
-                ],
-              ),
-              Expanded(
-                child: LayoutBuilder(
-                  builder: (BuildContext context, BoxConstraints constraints) {
-                    // Calculate how many columns we want depending on available space
-                    int colCount = max(1, (constraints.maxWidth / 250).floor());
-                    return Scrollbar(
-                      isAlwaysShown: DeviceType.isDesktop,
-                      controller: _scrollController,
-                      child: GridView.count(
-                          controller: _scrollController,
-                          padding: EdgeInsets.all(Insets.extraLarge),
-                          childAspectRatio: 1,
-                          crossAxisCount: colCount,
-                          children: listChildren),
-                    );
-                  },
-                ),
-              ),
+              StyledTextButton(onPressed: _handleSelectAllPressed, child: Text("Select All")),
+              StyledTextButton(onPressed: _handleSelectNonePressed, child: Text("Select None")),
             ],
           ),
-        ),
+          Expanded(
+            child: LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+                // Calculate how many columns we want depending on available space
+                int colCount = max(1, (constraints.maxWidth / 250).floor());
+                return Scrollbar(
+                  isAlwaysShown: DeviceType.isDesktop,
+                  controller: _scrollController,
+                  child: GridView.count(
+                      controller: _scrollController,
+                      padding: EdgeInsets.all(Insets.extraLarge),
+                      childAspectRatio: 1,
+                      crossAxisCount: colCount,
+                      children: listChildren),
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -113,23 +113,9 @@ class _GridItem extends StatelessWidget {
   }
 }
 
-/// Actions and Intents to support keyboard shortcuts
+/// Intents to support keyboard shortcuts
 class DeleteIntent extends Intent {}
-
-class DeleteAction extends Action<DeleteIntent> {
-  DeleteAction(this.action);
-  final VoidCallback action;
-
-  @override
-  void invoke(covariant DeleteIntent intent) => action.call();
-}
 
 class SelectAllIntent extends Intent {}
 
-class SelectAllAction extends Action<SelectAllIntent> {
-  SelectAllAction(this.action);
-  final VoidCallback action;
-
-  @override
-  void invoke(covariant SelectAllIntent intent) => action.call();
-}
+class SelectNoneIntent extends Intent {}


### PR DESCRIPTION
This adds a [TargetedActionScope] and [TargetedActionBindings] widget to allow for defining actions that take have key bindings at a higher level, but need a particular context to be invoked.

cc @esDotDev this should help address the problem you were having.